### PR TITLE
Fixed typo in string literal for GoodIronSwordBuilder

### DIFF
--- a/DesignPatterns/Builder/GoodIronSwordBuilder.cs
+++ b/DesignPatterns/Builder/GoodIronSwordBuilder.cs
@@ -24,7 +24,7 @@ namespace DesignPatterns.Builder
 
         public override void SetAdditives()
         {
-            this.Sword.Additives = new Dust() {Name = "Daimond Dust"};
+            this.Sword.Additives = new Dust() {Name = "Diamond Dust"};
         }
     }
 }


### PR DESCRIPTION
Based on https://en.wikipedia.org/wiki/Diamond_dust.